### PR TITLE
docs: Updated wording to match text in WWise installer

### DIFF
--- a/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
@@ -308,7 +308,7 @@ If anything is selected by default, do not uncheck them. They are required for V
 
 Click `Next` (you may need to scroll down to see the button).
 You don't need to add any plugins,
-so press `Deselect All` in the top right then `Install` in the bottom left to begin the installation process.
+so press `Select None` in the top right then `Install` in the bottom left to begin the installation process.
 Accept the terms and conditions prompts that appear along the way.
 
 == Satisfactory Mod Manager


### PR DESCRIPTION
The button says "Select None" now